### PR TITLE
improve performance of readonly field check

### DIFF
--- a/Apex.Serialization/Internal/Reflection/FieldInfoModifier.cs
+++ b/Apex.Serialization/Internal/Reflection/FieldInfoModifier.cs
@@ -9,7 +9,7 @@ namespace Apex.Serialization.Internal.Reflection
     // If I didn't do it, then someone else would
     internal static class FieldInfoModifier
     {
-        internal class TestReadonly
+        internal sealed class TestReadonly
         {
             public TestReadonly()
             {
@@ -60,7 +60,7 @@ namespace Apex.Serialization.Internal.Reflection
                     , fieldInfoParam
                     ).Compile();
 
-                var s = Binary.Create(new Settings());
+                var s = Binary.Create(new Settings { UseSerializedVersionId = false });
                 try
                 {
                     var test = new TestReadonly(5);


### PR DESCRIPTION
The documentation recommends using sealed types for improved performance. However, the serialization round-trip done as part of checking if readonly fields can be written to without reflection serializes a non-sealed type with a version ID, triggering the assembly scanning slow path. It seems like it would be safe to change it to a sealed type and serialize it without the version ID?